### PR TITLE
Implement required flush method

### DIFF
--- a/src/Instrument.php
+++ b/src/Instrument.php
@@ -79,4 +79,14 @@ class Instrument implements DatabaseInterface
     {
         self::$database->gauge($event, $tags, $value);
     }
+
+    /**
+     * Flush any queued writes
+     *
+     * @return void
+     */
+    public function flush(): void
+    {
+        self::$database->flush();
+    }
 }


### PR DESCRIPTION
Without this method, PHP throws an error about an unimplemented method mandates by the DatabaseInterface interface.