### PR TITLE
fix: call to deprecated ResourceInfoFactory::merge()

### DIFF
--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -152,7 +152,7 @@ class ServiceProvider extends LaravelServiceProvider
 
             return TracerProvider::builder()
                 ->setSampler($sampler)
-                ->setResource(ResourceInfoFactory::merge($resourceInfo, ResourceInfoFactory::defaultResource()))
+                ->setResource($resourceInfo->merge($resourceInfo, ResourceInfoFactory::defaultResource()))
                 ->addSpanProcessor($processor)
                 ->build();
         });


### PR DESCRIPTION
```
#22 [composer 8/8] RUN composer install --prefer-dist
#22 0.263 Installing dependencies from lock file (including require-dev)
#22 0.267 Verifying lock file contents can be installed on current platform.
#22 0.306 Nothing to install, update or remove
#22 0.323 Package php-http/message-factory is abandoned, you should avoid using it. Use psr/http-factory instead.
#22 0.323 Package fzaninotto/faker is abandoned, you should avoid using it. No replacement was suggested.
#22 0.323 Generating optimized autoload files
#22 7.787 > Illuminate\Foundation\ComposerScripts::postAutoloadDump
#22 7.821 > @php artisan package:discover --ansi
#22 7.994 
#22 7.995    Error 
#22 7.995 
#22 7.995   Call to undefined method OpenTelemetry\SDK\Resource\ResourceInfoFactory::merge()
#22 7.996 
#22 7.996   at vendor/***/instrumentation/src/Laravel/ServiceProvider.php:155
#22 7.997     151▕             register_shutdown_function(fn () => $processor->shutdown());
#22 7.997     152▕ 
#22 7.997     153▕             return TracerProvider::builder()
#22 7.997     154▕                 ->setSampler($sampler)
#22 7.997   ➜ 155▕                 ->setResource(ResourceInfoFactory::merge($resourceInfo, ResourceInfoFactory::defaultResource()))
#22 7.997     156▕                 ->addSpanProcessor($processor)
#22 7.997     157▕                 ->build();
#22 7.997     158▕         });
#22 7.997     159▕
```

caused by

https://github.com/open-telemetry/opentelemetry-php/commit/62a14d1c20db456baabbabf003f5efdbf0b030da#diff-4f2424608cd861f3fbc87e791f98577f9c217fb5088dc8080a3805aca6106137