### PR TITLE
fix: record_output does not exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "^8.2",
-        "plunkettscott/laravel-otel": "^0.4.1"
+        "plunkettscott/laravel-otel": "^0.4.2"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0 || ^9.0",


### PR DESCRIPTION
see https://github.com/plunkettscott/laravel-otel/releases/tag/v0.4.2

this PR makes it explicit that `v0.4.2` is required

this could have also been achieved by using `composer update stickee/instrumentation -W` which updates all the dependencies, however by being explicit in this repo the fix is included without having to use the `-W` option