### PR TITLE
Check for v2/v3 API not v1

### DIFF
--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
-use InfluxDB\Database;
+use InfluxDB2\Client;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use OpenTelemetry\API\LoggerHolder;
@@ -95,7 +95,7 @@ class ServiceProvider extends LaravelServiceProvider
      */
     private function registerInfluxDb(): void
     {
-        if (!class_exists(Database::class)) {
+        if (!class_exists(Client::class)) {
             $this->app->bind(InfluxDb::class, function () {
                 throw new Exception('InfluxDB client library not installed, please run: composer require influxdata/influxdb-client-php');
             });


### PR DESCRIPTION
Fix failing to initialize if the deprecated v1 API is not installed.