### PR TITLE
chore: remove monolog handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "open-telemetry/exporter-otlp": "^1.1",
         "open-telemetry/opentelemetry-auto-laravel": "^0.0.28",
         "open-telemetry/opentelemetry-auto-psr18": "^1.0",
-        "open-telemetry/opentelemetry-logger-monolog": "^1.0",
         "open-telemetry/sdk": "^1.1@beta"
     },
     "require-dev": {


### PR DESCRIPTION
The [Laravel auto instrumentation package will listen for logs and output them as OTLP](https://github.com/opentelemetry-php/contrib-auto-laravel/blob/main/src/Watchers/LogWatcher.php). 

This means we don't need to explicitly set a log handler and change to use it.