### PR TITLE
feat: set resource info on logger provider

### DIFF
--- a/src/Laravel/Providers/OpenTelemetryServiceProvider.php
+++ b/src/Laravel/Providers/OpenTelemetryServiceProvider.php
@@ -150,6 +150,7 @@ class OpenTelemetryServiceProvider extends ServiceProvider
 
         return LoggerProvider::builder()
             ->addLogRecordProcessor($processor)
+            ->setResource($this->getResourceInfo())
             ->build();
     }
 


### PR DESCRIPTION
not sure setting default resource here has the effect we want

consider these 2 spans from an example app:

```
    Service:pet-insurance
    Duration:653.95ms
    Start Time:0μs (13:15:43.967)
    Child Count:8
    Kind:server
    Status:unset
    Library Name:io.opentelemetry.contrib.php.laravel

 ```
 and
 ```
    Service:pet-insurance-1171
    Duration:149.32ms
    Start Time:259.36ms (13:15:44.226)
    Kind:client
    Status:unset
    Library Name:io.opentelemetry.contrib.php.laravel
```

the first was created by `auto-laravel` before anything else was booted and uses the ENV variable for `service.name` of `pet-insurance`
the second was also created by `auto-laravel`, but after `stickee/instrumentation` was booted, and uses the manually set `service.name` of `config('app.name')`

they are both created at different times using different values
I am starting to think we should remove setting resource information like this and prefer all `service.name`s be set by the ENV variable, so what works for `auto-laravel` also does the same thing for the "manual" instrumentation we do in `stickee/instrumentation`.