### PR TITLE
fix: config data scrubber passing int when a string is required

### DIFF
--- a/src/DataScrubbers/ConfigDataScrubber.php
+++ b/src/DataScrubbers/ConfigDataScrubber.php
@@ -40,7 +40,7 @@ class ConfigDataScrubber implements DataScrubberInterface
 
         foreach (array_keys($config) as $configKey) {
             foreach ($configKeyRegexes as $pattern) {
-                if (preg_match($pattern, $configKey)) {
+                if (preg_match($pattern, (string) $configKey)) {
                     $this->regexes['/' . preg_quote($config[$configKey], '/') . '/'] = '[REDACTED_CONFIG_VALUE:' . $configKey . ']';
                 }
             }


### PR DESCRIPTION
This PR fixes the config data scrubber potentially passing an int to `preg_match` which wants a string.