### PR TITLE
chore: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,10 @@ updates:
       directory: "/"
       schedule:
           interval: "daily"
-      target-branch: "master"
+      target-branch: "main"
 
     - package-ecosystem: "composer"
       directory: "/"
       schedule:
           interval: "daily"
-      target-branch: "master"
+      target-branch: "main"


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/dependabot.yml` file. The change updates the target branch from "master" to "main" for consistency and to align with "modern" naming conventions.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L10-R16): Changed `target-branch` from "master" to "main" for both the default package ecosystem and the composer package ecosystem.